### PR TITLE
Query string check

### DIFF
--- a/wp-force-lowercase-urls.php
+++ b/wp-force-lowercase-urls.php
@@ -35,7 +35,7 @@ if ( !class_exists('WPForceLowercaseURLs') ) {
 
       // Grab requested URL
       $url = $_SERVER['REQUEST_URI'];
-      $params = $_SERVER['QUERY_STRING'];
+      $params = (isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '');
 
       // If URL contains a period, halt (likely contains a filename and filenames are case specific)
       if ( preg_match('/[\.]/', $url) ) {


### PR DESCRIPTION
Check if the $_SERVER['QUERY_STRING'] is present to prevent unnecessary notices being generated when it's not

Addresses issue #3 